### PR TITLE
Decrease max bone count

### DIFF
--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -299,6 +299,7 @@ void FRenderableManager::create(
             // renderables. In the future we could try addressing this by implementing a paging
             // system such that multiple skinned renderables will share regions within a single
             // large block of bones.
+            assert(count<=CONFIG_MAX_BONE_COUNT);
             bones = std::unique_ptr<Bones>(new Bones{
                     driver.createUniformBuffer(CONFIG_MAX_BONE_COUNT * sizeof(PerRenderableUibBone),
                             backend::BufferUsage::DYNAMIC),

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -59,7 +59,8 @@ constexpr size_t CONFIG_MAX_LIGHT_INDEX = CONFIG_MAX_LIGHT_COUNT - 1;
 
 // This value is also limited by UBO size, ES3.0 only guarantees 16 KiB.
 // We store 64 bytes per bone.
-constexpr size_t CONFIG_MAX_BONE_COUNT = 256;
+// On some webGL platforms we only have 256 vec4s (defined by GL_MAX_VERTEX_UNIFORM_VECTORS) not 16Kib, so has to be smaller still
+constexpr size_t CONFIG_MAX_BONE_COUNT = 64;
 
 } // namespace filament
 


### PR DESCRIPTION
On the Linux WebGL implementations used in CI we can't have more than 64 bone matrices as GL_MAX_VERTEX_UNIFORM_VECTORS is only 256.  I've dropped the max bone count down to 64, to avoid this issue (will require material rebuild)

