### PR TITLE
Shrink max bones again

### DIFF
--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -60,7 +60,7 @@ constexpr size_t CONFIG_MAX_LIGHT_INDEX = CONFIG_MAX_LIGHT_COUNT - 1;
 // This value is also limited by UBO size, ES3.0 only guarantees 16 KiB.
 // We store 64 bytes per bone.
 // On some webGL platforms we only have 256 vec4s (defined by GL_MAX_VERTEX_UNIFORM_VECTORS) not 16Kib, so has to be smaller still
-constexpr size_t CONFIG_MAX_BONE_COUNT = 64;
+constexpr size_t CONFIG_MAX_BONE_COUNT = 56;
 
 } // namespace filament
 


### PR DESCRIPTION
Having fought with VirtualBox to try and build a VM I can test in linux browser, and failed for now, it may be quicker to do this by trial and error :(

This is bumps the bone count down again to 56, giving 32 vec4s for other UBOs in the vertex shader.  Should be enough?  But only way to test is to run on the CI machines, so we'll see.
